### PR TITLE
style: 비디오 녹화 화면 스타일링

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-grid-system": "^7.0.3",
+    "react-headroom": "^3.0.0",
     "recoil": "^0.0.10",
     "recordrtc": "^5.6.1",
     "styled-components": "^5.1.1"
@@ -37,6 +38,7 @@
     "@types/node": "^14.0.22",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
+    "@types/react-headroom": "^2.2.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-styled-components": "^1.10.7",
     "eslint-plugin-react": "^7.20.3"

--- a/client/pages/add-video.tsx
+++ b/client/pages/add-video.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
+import EditorToolBar from '@src/components/editor-page/EditorToolBar';
 
 const VideoEditTest = dynamic(() => import('../src/components/VideoEdit'), {
   ssr: false,
@@ -7,6 +8,11 @@ const VideoEditTest = dynamic(() => import('../src/components/VideoEdit'), {
 
 export default () => (
   <div>
+    <EditorToolBar
+      name="비디오 테스트"
+      lectureName="강의 이름"
+    />
+    <div style={{height: 120}} />
     <VideoEditTest />
   </div>
 );

--- a/client/src/assets/next-slide.svg
+++ b/client/src/assets/next-slide.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>skip-slide</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="skip-slide" fill="#000000" fill-rule="nonzero">
+            <path d="M10,0 C4.48,0 0,4.48 0,10 C0,15.52 4.48,20 10,20 C15.52,20 20,15.52 20,10 C20,4.48 15.52,0 10,0 Z M16,11.97 L11,11.97 L13.26,9.71 C12.35,8.65 11.01,7.97 9.5,7.97 C7.13,7.97 5.15,9.63 4.64,11.85 L3.68,11.53 C4.32,8.91 6.68,6.97 9.5,6.97 C11.28,6.97 12.87,7.76 13.97,9 L16,6.97 L16,11.97 Z" id="Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/client/src/assets/previous-slide.svg
+++ b/client/src/assets/previous-slide.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>Shape</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="skip-slide" fill="#000000" fill-rule="nonzero">
+            <path d="M10,0 C4.48,0 0,4.48 0,10 C0,15.52 4.48,20 10,20 C15.52,20 20,15.52 20,10 C20,4.48 15.52,0 10,0 Z M16,11.97 L11,11.97 L13.26,9.71 C12.35,8.65 11.01,7.97 9.5,7.97 C7.13,7.97 5.15,9.63 4.64,11.85 L3.68,11.53 C4.32,8.91 6.68,6.97 9.5,6.97 C11.28,6.97 12.87,7.76 13.97,9 L16,6.97 L16,11.97 Z" id="Shape" transform="translate(10.000000, 10.000000) scale(-1, 1) translate(-10.000000, -10.000000) "></path>
+        </g>
+    </g>
+</svg>

--- a/client/src/assets/start-recording.svg
+++ b/client/src/assets/start-recording.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="12px" viewBox="0 0 18 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>start-recording</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="start-recording" fill="#000000" fill-rule="nonzero">
+            <path d="M14,4.5 L14,1 C14,0.45 13.55,0 13,0 L1,0 C0.45,0 0,0.45 0,1 L0,11 C0,11.55 0.45,12 1,12 L13,12 C13.55,12 14,11.55 14,11 L14,7.5 L18,11.5 L18,0.5 L14,4.5 Z" id="Path"></path>
+        </g>
+    </g>
+</svg>

--- a/client/src/assets/stop-recording.svg
+++ b/client/src/assets/stop-recording.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="19px" height="19px" viewBox="0 0 19 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>stop-recording</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="skip-slide" transform="translate(-45.000000, -2.000000)" fill="#000000" fill-rule="nonzero">
+            <g id="stop-recording" transform="translate(45.000000, 2.000000)">
+                <path d="M19,4.5 L15,8.5 L15,5 C15,4.45 14.55,4 14,4 L7.82,4 L19,15.18 L19,4.5 Z M1.27,0 L0,1.27 L2.73,4 L2,4 C1.45,4 1,4.45 1,5 L1,15 C1,15.55 1.45,16 2,16 L14,16 C14.21,16 14.39,15.92 14.54,15.82 L17.73,19 L19,17.73 L1.27,0 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/client/src/components/Editor/index.tsx
+++ b/client/src/components/Editor/index.tsx
@@ -1,16 +1,69 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useLayoutEffect, useRef, useEffect } from 'react';
 import EditorJS, { EditorConfig, OutputData, LogLevels } from '@editorjs/editorjs';
 import Header from '@editorjs/header';
 import List from '@editorjs/list';
 import Underline from '@editorjs/underline';
 import Marker from '@editorjs/marker';
+import styled from 'styled-components';
 import QuizBlockPlugin from './QuizBlock/plugin';
 import EditorWrapper from '@src/styles/EditorWrapper';
-import styled from 'styled-components';
 
 const editorJsConfig: EditorConfig = {
   onChange: (change) => { console.log('editorJS', change); },
   logLevel: 'WARN' as LogLevels.WARN,
+  i18n: {
+    messages: {
+      ui: {
+        'blockTunes': {
+          'toggler': {
+            'Click to tune': '클릭해서 블록 변경',
+          },
+        },
+        inlineToolbar: {
+          converter: {
+            'Convert to': '변환',
+          },
+        },
+        toolbar: {
+          toolbox: {
+            Add: '추가',
+          },
+        },
+      },
+
+      toolNames: {
+        Text: '텍스트',
+        Heading: '제목',
+        List: '리스트',
+        Link: '링크',
+        Marker: '형광펜',
+        Bold: '굵게',
+        Italic: '기울게',
+        Underline: '밑줄',
+      },
+      tools: {
+        link: {
+          'Add a link': '링크 추가',
+        },
+        stub: {
+          'The block can not be displayed correctly.':
+            '블록 표시 중 문제가 발생했습니다.',
+        },
+      },
+
+      blockTunes: {
+        delete: {
+          Delete: '삭제',
+        },
+        moveUp: {
+          'Move up': '위로 이동',
+        },
+        moveDown: {
+          'Move down': '아래로 이동',
+        },
+      },
+    },
+  },
   tools: {
     header: Header,
     list: List,
@@ -50,9 +103,15 @@ const Editor: React.FC<EditorProps> = ({ data, onChange, onSelectionChange, sele
   const editorRef = useRef<EditorJS | null>(null);
   const editorElRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    editorRef.current = new EditorJS(Object.assign({}, editorJsConfig, { data, holder: editorElRef.current }));
-    // new EditorJS({...editorJsConfig, holder: 'editor9'});
+  useLayoutEffect(() => {
+    const editor = new EditorJS(
+      Object.assign(
+        {},
+        editorJsConfig,
+        { data, holder: editorElRef.current }
+      )
+    );
+    editorRef.current = editor;
   }, []);
 
   const editorHighlightLayerElRef = useRef<HTMLDivElement>(null);

--- a/client/src/components/VideoEdit/Slide/index.tsx
+++ b/client/src/components/VideoEdit/Slide/index.tsx
@@ -3,51 +3,94 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 import produce from 'immer';
 import { OutputData } from '@editorjs/editorjs';
 import Editor, { EditorTextSelection } from '@src/components/Editor';
-import { editorTextDataState, editorPreviewHighlightState, slideState } from '../states';
+import {
+  editorTextDataState,
+  editorPreviewHighlightState,
+  slideState,
+} from '../states';
 
-const Slide: React.FC<{ slideIndex: number; selected?: boolean }> = ({ slideIndex, selected }) => {
+import * as S from './styles';
+
+interface SlideProps {
+  slideIndex: number;
+  selected?: boolean;
+  onFocused?: (index: number) => void;
+}
+
+const Slide: React.FC<SlideProps> = ({ slideIndex, selected, onFocused }) => {
   const editorData = useRecoilValue(editorTextDataState(slideIndex));
-  const previewSelectionData = useRecoilValue(editorPreviewHighlightState(slideIndex));
-  
-  const [currentSlide, setCurrentSlide] = useRecoilState(slideState(slideIndex));
-  
-  const addTextChange = useCallback<(data: OutputData) => void>((textData: OutputData) => {
-    setCurrentSlide((state) => produce(state, (draftState) => {
-      draftState.changes.push({ data: textData, videoTimestamp: (new Date().getTime() - currentSlide.recordingStartedAt) / 1000 });
-    }));
-  }, [currentSlide.recordingStartedAt, setCurrentSlide]);
-  
-  // TODO: Node기반 position으로 바꾸어 responsive하게 동작하게 만들기 
+  const previewSelectionData = useRecoilValue(
+    editorPreviewHighlightState(slideIndex)
+  );
+
+  const [currentSlide, setCurrentSlide] = useRecoilState(
+    slideState(slideIndex)
+  );
+
+  const addTextChange = useCallback<(data: OutputData) => void>(
+    (textData: OutputData) => {
+      setCurrentSlide((state) =>
+        produce(state, (draftState) => {
+          draftState.changes.push({
+            data: textData,
+            videoTimestamp:
+              (new Date().getTime() - currentSlide.recordingStartedAt) / 1000,
+          });
+        })
+      );
+    },
+  [currentSlide.recordingStartedAt, setCurrentSlide]
+  );
+
+  // TODO: Node기반 position으로 바꾸어 responsive하게 동작하게 만들기
   const addSelectionChange = (rects?: EditorTextSelection[]) => {
-    setCurrentSlide((state) => produce(state, (draftState) => {
-      draftState.selectionChanges.push({ data: rects, videoTimestamp: (new Date().getTime() - currentSlide.recordingStartedAt) / 1000 });
-    }));
+    setCurrentSlide((state) =>
+      produce(state, (draftState) => {
+        draftState.selectionChanges.push({
+          data: rects,
+          videoTimestamp:
+            (new Date().getTime() - currentSlide.recordingStartedAt) / 1000,
+        });
+      })
+    );
   };
-  
+
   const handleTextDataChange = useCallback<(data: OutputData) => void>(
     (textData) => {
       if (!currentSlide.isRecording) {
         return;
       }
       addTextChange(textData);
-    }, [addTextChange, currentSlide.isRecording]);
-  
+    },
+  [addTextChange, currentSlide.isRecording]
+  );
+
   const handleSelectionChange = (rects?: EditorTextSelection[]) => {
     if (!currentSlide.isRecording) {
       return;
     }
     addSelectionChange(rects);
   };
-  
+
+  const handleFocused: React.FocusEventHandler = () => {
+    if(!onFocused) {
+      return;
+    }
+    onFocused(slideIndex);
+  };
+
   return (
-    <div style={{ backgroundColor: selected ? 'yellow' : undefined }}>
+    <S.CardView
+      isSelected={selected}
+      onFocus={handleFocused}
+    >
       <Editor
         data={editorData}
         onChange={handleTextDataChange}
         selection={previewSelectionData}
         onSelectionChange={handleSelectionChange}
       />
-    </div>
+    </S.CardView>
   );
 };
 

--- a/client/src/components/VideoEdit/Slide/index.tsx
+++ b/client/src/components/VideoEdit/Slide/index.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback } from 'react';
+import { useRecoilValue, useRecoilState } from 'recoil';
+import produce from 'immer';
+import { OutputData } from '@editorjs/editorjs';
+import Editor, { EditorTextSelection } from '@src/components/Editor';
+import { editorTextDataState, editorPreviewHighlightState, slideState } from '../states';
+
+const Slide: React.FC<{ slideIndex: number; selected?: boolean }> = ({ slideIndex, selected }) => {
+  const editorData = useRecoilValue(editorTextDataState(slideIndex));
+  const previewSelectionData = useRecoilValue(editorPreviewHighlightState(slideIndex));
+  
+  const [currentSlide, setCurrentSlide] = useRecoilState(slideState(slideIndex));
+  
+  const addTextChange = useCallback<(data: OutputData) => void>((textData: OutputData) => {
+    setCurrentSlide((state) => produce(state, (draftState) => {
+      draftState.changes.push({ data: textData, videoTimestamp: (new Date().getTime() - currentSlide.recordingStartedAt) / 1000 });
+    }));
+  }, [currentSlide.recordingStartedAt, setCurrentSlide]);
+  
+  // TODO: Node기반 position으로 바꾸어 responsive하게 동작하게 만들기 
+  const addSelectionChange = (rects?: EditorTextSelection[]) => {
+    setCurrentSlide((state) => produce(state, (draftState) => {
+      draftState.selectionChanges.push({ data: rects, videoTimestamp: (new Date().getTime() - currentSlide.recordingStartedAt) / 1000 });
+    }));
+  };
+  
+  const handleTextDataChange = useCallback<(data: OutputData) => void>(
+    (textData) => {
+      if (!currentSlide.isRecording) {
+        return;
+      }
+      addTextChange(textData);
+    }, [addTextChange, currentSlide.isRecording]);
+  
+  const handleSelectionChange = (rects?: EditorTextSelection[]) => {
+    if (!currentSlide.isRecording) {
+      return;
+    }
+    addSelectionChange(rects);
+  };
+  
+  return (
+    <div style={{ backgroundColor: selected ? 'yellow' : undefined }}>
+      <Editor
+        data={editorData}
+        onChange={handleTextDataChange}
+        selection={previewSelectionData}
+        onSelectionChange={handleSelectionChange}
+      />
+    </div>
+  );
+};
+
+export default Slide;

--- a/client/src/components/VideoEdit/Slide/styles.ts
+++ b/client/src/components/VideoEdit/Slide/styles.ts
@@ -1,0 +1,20 @@
+import styled, { css } from 'styled-components';
+import hexToRgba from '@src/styles/hexToRgba';
+
+const selectedStyle = css`
+  border: solid 0.125rem ${({theme}) => hexToRgba(theme.colors.text.default, 0.1)};
+`;
+
+export const CardView = styled.div<{isSelected: boolean}>`
+  border: solid 0.125rem transparent;
+  ${({isSelected}) => isSelected ? selectedStyle : undefined}
+  padding: 1rem 2rem 2rem;
+  margin-bottom: 4.5rem;
+  border-radius: 0.25rem;
+
+  transition: border 0.3s ease-in-out;
+
+  .codex-editor__redactor {
+    padding: 0 !important;
+  }
+`;

--- a/client/src/components/VideoEdit/VideoRecordingController/index.tsx
+++ b/client/src/components/VideoEdit/VideoRecordingController/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import FlatButton from '@src/components/common/FlatButton';
+
+import * as S from './styles';
+
+interface VideoRecordingControllerProps {
+  onPressPrevious?: React.MouseEventHandler;
+  onPressNext?: React.MouseEventHandler;
+  onPressRecording?: React.MouseEventHandler;
+  onPressStop?: React.MouseEventHandler;
+}
+
+const VideoRecordingController: React.FC<VideoRecordingControllerProps> = ({
+  onPressPrevious,
+  onPressNext,
+  onPressRecording,
+  onPressStop,
+}) => {
+  return (
+    <S.ControllerWrapper>
+      <S.IconButton
+        onClick={onPressPrevious}
+        isDisabled={!onPressPrevious}
+      >
+        <S.PreviousSlideIcon />
+      </S.IconButton>
+      {!!onPressStop && (
+        <S.IconButton onClick={onPressStop}>
+          <S.StopRecordingIcon />
+        </S.IconButton>
+      )}
+      {!!onPressRecording && (
+        <S.IconButton onClick={onPressRecording}>
+          <S.StopRecordingIcon />
+        </S.IconButton>
+      )}
+      <S.IconButton 
+        onClick={onPressNext}
+        isDisabled={!onPressNext}
+      >
+        <S.NextSlideIcon />
+      </S.IconButton>
+    </S.ControllerWrapper>
+  );
+};
+
+export default VideoRecordingController;

--- a/client/src/components/VideoEdit/VideoRecordingController/styles.ts
+++ b/client/src/components/VideoEdit/VideoRecordingController/styles.ts
@@ -1,0 +1,71 @@
+import styled, {css} from 'styled-components';
+
+import StartRecordingSvg from '@src/assets/start-recording.svg';
+import StopRecordingSvg from '@src/assets/stop-recording.svg';
+import NextSlideSvg from '@src/assets/next-slide.svg';
+import PreviousSlideSvg from '@src/assets/previous-slide.svg';
+import hexToRgba from '@src/styles/hexToRgba';
+
+export const ControllerWrapper = styled.div`
+  display: flex;
+  width: fit-content;
+  justify-content: space-around;
+  align-items: center;
+  margin: 1rem auto 0;
+  padding: 0.25rem 1rem;
+  border-radius: 0.5rem;
+  background: ${({theme}) => theme.colors.black};
+`;
+
+export const IconButton = styled.div<{isDisabled?: boolean}>`
+  cursor: pointer;
+  display: flex;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  transition: background 0.15s ease-in-out;
+  align-self: stretch;
+  align-items: center;
+  margin: 0 0.25rem;
+
+  &:hover {
+    background: ${({theme}) => hexToRgba(theme.colors.primary, 0.2)};
+    path {
+      fill: ${({theme}) => theme.colors.primary};
+    }
+  }
+
+  ${({isDisabled}) => isDisabled ? css`
+    path {
+      opacity: 0.5;
+    }
+    &:hover {
+      background: transparent;
+      path {
+        fill: ${({theme}) => theme.colors.white};
+      }
+    }
+  ` : undefined}
+`;
+
+export const iconStyle = css`
+  path {
+    fill: white;
+    transition: fill 0.15s ease-in-out, opacity 0.15s ease-in-out;
+  }
+`;
+
+export const StartRecordingIcon = styled(StartRecordingSvg)`
+  ${iconStyle}
+`;
+
+export const StopRecordingIcon = styled(StopRecordingSvg)`
+  ${iconStyle}
+`;
+
+export const NextSlideIcon = styled(NextSlideSvg)`
+  ${iconStyle}
+`;
+
+export const PreviousSlideIcon = styled(PreviousSlideSvg)`
+  ${iconStyle}
+`;

--- a/client/src/components/VideoEdit/index.tsx
+++ b/client/src/components/VideoEdit/index.tsx
@@ -2,22 +2,28 @@ import React, { ChangeEventHandler, useEffect } from 'react';
 import RecordRTC from 'recordrtc';
 import { RecoilRoot, useRecoilState } from 'recoil';
 import produce from 'immer';
-import {
-  CameraVideo,
-  EditorContainer,
-  PreviewVideo,
-  RecordButton,
-  Scaffold,
-  VideoContainer,
-} from './styles';
+
 import { getCameraMirrorRefCallback } from './utils';
 import { slideEditorState, createNewSlideData, slideState } from './states';
+
+import * as S from './styles';
 import Slide from './Slide';
 
 let recorder: RecordRTC;
 
 const VideoEdit: React.FC = () => {
+  const [slideEditor, setSlideEditor] = useRecoilState(slideEditorState);
+  const { currentSlideIndex } = slideEditor;
+  const [currentSlide, setCurrentSlide] = useRecoilState(
+    slideState(currentSlideIndex)
+  );
+
   const videoRefCallback = getCameraMirrorRefCallback();
+
+  // a state observer for debugging
+  useEffect(() => {
+    console.log('ATOM', currentSlide);
+  }, [currentSlide]);
 
   useEffect(() => {
     navigator.mediaDevices
@@ -25,27 +31,16 @@ const VideoEdit: React.FC = () => {
       .then((stream) => {
         recorder = new RecordRTC(stream, {
           type: 'video',
-          video: { width: 1920, height: 1080 },
+          video: { width: 1280, height: 720 },
         });
       });
   }, []);
-
-  const [slideEditor, setSlideEditor] = useRecoilState(slideEditorState);
-  const { currentSlideIndex } = slideEditor;
-  const [currentSlide, setCurrentSlide] = useRecoilState(
-    slideState(currentSlideIndex)
-  );
-
-  // a state observer for debugging
-  useEffect(() => {
-    console.log('ATOM', currentSlide);
-  }, [currentSlide]);
 
   const setCurrentSlideIndex = (index: number) => {
     setSlideEditor({ ...slideEditor, currentSlideIndex: index });
   };
 
-  const addDefaultSlideToLast = () => {
+  const addNewSlide = () => {
     setSlideEditor((state) =>
       produce(state, (draftState) => {
         draftState.slides.push(createNewSlideData());
@@ -81,7 +76,6 @@ const VideoEdit: React.FC = () => {
     setCurrentSlide((state) => ({ ...state, previewCurrentTime: currentTime }));
   };
 
-  // Handlers
   const handleStartClick = () => {
     if (currentSlide.isRecording) {
       return;
@@ -108,8 +102,8 @@ const VideoEdit: React.FC = () => {
   };
 
   return (
-    <Scaffold>
-      <EditorContainer>
+    <S.Scaffold>
+      <S.EditorContainer>
         {slideEditor.slides.map(({ id }, index) => (
           <button
             key={id}
@@ -123,7 +117,7 @@ const VideoEdit: React.FC = () => {
         ))}
         <button
           onClick={() => {
-            addDefaultSlideToLast();
+            addNewSlide();
           }}
         >
           +
@@ -137,24 +131,25 @@ const VideoEdit: React.FC = () => {
             />
           );
         })}
-      </EditorContainer>
-      <VideoContainer>
-        <CameraVideo ref={videoRefCallback}
+      </S.EditorContainer>
+      <S.VideoContainer>
+        <S.CameraVideo
+          ref={videoRefCallback}
           autoPlay
           controls={false}
           muted
         />
         {!currentSlide.isRecording ? (
-          <RecordButton onClick={handleStartClick}>
+          <S.RecordButton onClick={handleStartClick}>
             start recording
-          </RecordButton>
+          </S.RecordButton>
         ) : (
-          <RecordButton onClick={handleStopClick}>stop recording</RecordButton>
+          <S.RecordButton onClick={handleStopClick}>stop recording</S.RecordButton>
         )}
         {currentSlide.previewVideoObjectUrl && (
           <div>
             <h2>Record Preview</h2>
-            <PreviewVideo
+            <S.PreviewVideo
               onTimeUpdate={handlePreviewTimeUpdate}
               src={currentSlide.previewVideoObjectUrl}
               controls
@@ -162,8 +157,8 @@ const VideoEdit: React.FC = () => {
             />
           </div>
         )}
-      </VideoContainer>
-    </Scaffold>
+      </S.VideoContainer>
+    </S.Scaffold>
   );
 };
 

--- a/client/src/components/VideoEdit/index.tsx
+++ b/client/src/components/VideoEdit/index.tsx
@@ -8,6 +8,8 @@ import { slideEditorState, createNewSlideData, slideState } from './states';
 
 import * as S from './styles';
 import Slide from './Slide';
+import { Container, Row, Col } from 'react-grid-system';
+import FlatButton from '../common/FlatButton';
 
 let recorder: RecordRTC;
 
@@ -102,63 +104,66 @@ const VideoEdit: React.FC = () => {
   };
 
   return (
-    <S.Scaffold>
-      <S.EditorContainer>
-        {slideEditor.slides.map(({ id }, index) => (
-          <button
-            key={id}
-            style={{ color: index === currentSlideIndex ? 'red' : '#aaa' }}
-            onClick={() => {
-              setCurrentSlideIndex(index);
-            }}
-          >
-            {index}
-          </button>
-        ))}
+    <div style={{ position: 'relative', zIndex: 0 }}>
+      <Container>
+        <Row>
+          <Col sm={9}>
+            {slideEditor.slides.map(({ id }, index) => (
+              <Slide
+                key={id}
+                slideIndex={index}
+                selected={index === currentSlideIndex}
+                onFocused={setCurrentSlideIndex}
+              />
+            ))}
+          </Col>
+          <Col sm={3}>
+            <S.CameraVideo
+              ref={videoRefCallback}
+              autoPlay
+              controls={false}
+              muted
+            />
+            {!currentSlide.isRecording ? (
+              <FlatButton onClick={handleStartClick}>
+                start recording
+              </FlatButton>
+            ) : (
+              <FlatButton onClick={handleStopClick}>stop recording</FlatButton>
+            )}
+            {currentSlide.previewVideoObjectUrl && (
+              <div>
+                <h2>Record Preview</h2>
+                <S.CameraVideo
+                  onTimeUpdate={handlePreviewTimeUpdate}
+                  src={currentSlide.previewVideoObjectUrl}
+                  controls
+                  width="250"
+                />
+              </div>
+            )}
+          </Col>
+        </Row>
+      </Container>
+      {slideEditor.slides.map(({ id }, index) => (
         <button
+          key={id}
+          style={{ color: index === currentSlideIndex ? 'red' : '#aaa' }}
           onClick={() => {
-            addNewSlide();
+            setCurrentSlideIndex(index);
           }}
         >
-          +
+          {index}
         </button>
-        {slideEditor.slides.map(({ id }, index) => {
-          return (
-            <Slide
-              key={id}
-              slideIndex={index}
-              selected={index === currentSlideIndex}
-            />
-          );
-        })}
-      </S.EditorContainer>
-      <S.VideoContainer>
-        <S.CameraVideo
-          ref={videoRefCallback}
-          autoPlay
-          controls={false}
-          muted
-        />
-        {!currentSlide.isRecording ? (
-          <S.RecordButton onClick={handleStartClick}>
-            start recording
-          </S.RecordButton>
-        ) : (
-          <S.RecordButton onClick={handleStopClick}>stop recording</S.RecordButton>
-        )}
-        {currentSlide.previewVideoObjectUrl && (
-          <div>
-            <h2>Record Preview</h2>
-            <S.PreviewVideo
-              onTimeUpdate={handlePreviewTimeUpdate}
-              src={currentSlide.previewVideoObjectUrl}
-              controls
-              width="250"
-            />
-          </div>
-        )}
-      </S.VideoContainer>
-    </S.Scaffold>
+      ))}
+      <button
+        onClick={() => {
+          addNewSlide();
+        }}
+      >
+        +
+      </button>
+    </div>
   );
 };
 

--- a/client/src/components/VideoEdit/states.ts
+++ b/client/src/components/VideoEdit/states.ts
@@ -37,10 +37,10 @@ interface TextDataChange {
 // Editing에서만 originalEditorData를 변경할 수 있게
 // Previewing에서는 녹화한 강의 재생만 (contenteditable=false)
 enum EditingState {
-    Recording,
-    Editing,
-    Previewing,
-  }
+  Recording,
+  Editing,
+  Previewing,
+}
   
 export const initialData: OutputData = { 'time': 1595009894317, 'blocks': [{ 'type': 'header', 'data': { 'text': '새로운 강의 방식을 만들고 있어요.', 'level': 2 } }, { 'type': 'paragraph', 'data': { 'text': '노션처럼 쉬운 블록 기반 에디터와 중요한 정보를 효과적으로 알릴 수 있는 포맷팅 타임라인 기능.<br>웹에서 비디오 녹화까지.' } }, { 'type': 'paragraph', 'data': { 'text': '쉽게 제작하고, 효율적으로 온라인 강의를 체험해보세요' } }], 'version': '2.18.0' };
 

--- a/client/src/components/VideoEdit/states.ts
+++ b/client/src/components/VideoEdit/states.ts
@@ -1,0 +1,128 @@
+import { OutputData } from '@editorjs/editorjs';
+import { EditorTextSelection } from '../Editor';
+import { selectorFamily, atom, DefaultValue } from 'recoil';
+import { produce } from 'immer';
+interface SlideState {
+    id: string;
+    originalEditorData: OutputData;
+    changes: TextDataChange[];
+    selectionChanges: TextSelectionChange[];
+    isRecording: boolean;
+    recordingStartedAt: number;
+    previewVideoObjectUrl?: string;
+    previewCurrentTime: number;
+  }
+
+  
+interface TextDataChange {
+    data: OutputData;
+    videoTimestamp: number;
+  }
+  
+  interface TextSelectionChange {
+    data?: EditorTextSelection[];
+    videoTimestamp: number;
+  }
+
+  interface SlideEditorState {
+    currentSlideIndex: number;
+    slides: SlideState[];
+    // 아직 안씀
+    editingState: EditingState;
+  }
+    
+
+// TODO: 학생이 강의 재생하고 강사는 녹화하고 자료 수정하고 세 작업을 하려면 아래 플래그가 필요함
+// Recording에서만 change 기록 및 비디오 녹화
+// Editing에서만 originalEditorData를 변경할 수 있게
+// Previewing에서는 녹화한 강의 재생만 (contenteditable=false)
+enum EditingState {
+    Recording,
+    Editing,
+    Previewing,
+  }
+  
+export const initialData: OutputData = { 'time': 1595009894317, 'blocks': [{ 'type': 'header', 'data': { 'text': '새로운 강의 방식을 만들고 있어요.', 'level': 2 } }, { 'type': 'paragraph', 'data': { 'text': '노션처럼 쉬운 블록 기반 에디터와 중요한 정보를 효과적으로 알릴 수 있는 포맷팅 타임라인 기능.<br>웹에서 비디오 녹화까지.' } }, { 'type': 'paragraph', 'data': { 'text': '쉽게 제작하고, 효율적으로 온라인 강의를 체험해보세요' } }], 'version': '2.18.0' };
+
+export const defaultSlideData: SlideState = {
+  id: '0',
+  originalEditorData: initialData,
+  changes: [],
+  selectionChanges: [],
+  isRecording: false,
+  recordingStartedAt: 0,
+  previewVideoObjectUrl: undefined,
+  previewCurrentTime: 0,
+};
+
+export let idCounter = 10;
+
+export const createNewSlideData = () => {
+  idCounter++;
+  return Object.assign({ id: String(idCounter) }, defaultSlideData);
+};
+
+export const slideEditorState = atom<SlideEditorState>({
+  key: 'slideEditorState',
+  default: {
+    currentSlideIndex: 0,
+    slides: [createNewSlideData(), createNewSlideData()],
+    editingState: EditingState.Editing
+  },
+});
+
+export const slideState = selectorFamily<SlideState, number>({
+  key: 'slideState',
+  get: slideIndex => ({ get }) => {
+    const slideEditor = get(slideEditorState);
+    return slideEditor.slides[slideIndex];
+  },
+  set: slideIndex => ({ get, set }, newValue) => {
+    set(slideEditorState, produce(get(slideEditorState), draftState => {
+      if (newValue instanceof DefaultValue) {
+        draftState.slides[slideIndex] = defaultSlideData;
+        return;
+      }
+      draftState.slides[slideIndex] = newValue;
+    }));
+  },
+});
+
+export const latestTextChangeState = selectorFamily<OutputData, number>({
+  key: 'latestTextChangeState',
+  get: slideIndex => ({ get }) => {
+    const videoEdit = get(slideState(slideIndex));
+    const isChangeBeforeCurrentTime = (textChange: TextDataChange) => textChange.videoTimestamp <= videoEdit.previewCurrentTime;
+    const latestChangeBeforeCurrentTime = videoEdit.changes.filter(isChangeBeforeCurrentTime).slice(-1);
+    // 최근 수정 사항이 없으면 첫 text로 시작함
+    return (latestChangeBeforeCurrentTime.length > 0 ? latestChangeBeforeCurrentTime[0].data : videoEdit.originalEditorData);
+  },
+});
+
+export const editorTextDataState = selectorFamily<OutputData | undefined, number>({
+  key: 'editorTextDataState',
+  get: slideIndex => ({ get }) => {
+    const videoEdit = get(slideState(slideIndex));
+    // NO CONTROL WHEN ENABLED WRITING
+    if (videoEdit.isRecording) {
+      return;
+    }
+    // CONTROL
+    return get(latestTextChangeState(slideIndex));
+  },
+});
+
+export const editorPreviewHighlightState = selectorFamily<EditorTextSelection[] | undefined, number>({
+  key: 'editorPreviewHighlightState',
+  get: slideIndex => ({ get }) => {
+    const videoEdit = get(slideState(slideIndex));
+    // NO CONTROL WHEN ENABLED WRITING
+    if (videoEdit.isRecording) {
+      return;
+    }
+
+    const isChangeBeforeCurrentTime = (change: TextSelectionChange) => change.videoTimestamp <= videoEdit.previewCurrentTime;
+    const latestChangeBeforeCurrentTime = videoEdit.selectionChanges.filter(isChangeBeforeCurrentTime).slice(-1);
+    return (latestChangeBeforeCurrentTime.length > 0 ? latestChangeBeforeCurrentTime[0].data : undefined);
+  },
+});

--- a/client/src/components/VideoEdit/states.ts
+++ b/client/src/components/VideoEdit/states.ts
@@ -42,7 +42,7 @@ enum EditingState {
   Previewing,
 }
   
-export const initialData: OutputData = { 'time': 1595009894317, 'blocks': [{ 'type': 'header', 'data': { 'text': '새로운 강의 방식을 만들고 있어요.', 'level': 2 } }, { 'type': 'paragraph', 'data': { 'text': '노션처럼 쉬운 블록 기반 에디터와 중요한 정보를 효과적으로 알릴 수 있는 포맷팅 타임라인 기능.<br>웹에서 비디오 녹화까지.' } }, { 'type': 'paragraph', 'data': { 'text': '쉽게 제작하고, 효율적으로 온라인 강의를 체험해보세요' } }], 'version': '2.18.0' };
+export const initialData: OutputData = { 'time': 1595009894317, 'blocks': [{ 'type': 'header', 'data': { 'text': '새로운 강의 방식을 만들고 있어요.', 'level': 2 } }, { 'type': 'paragraph', 'data': { 'text': '노션처럼 쉬운 블록 기반 에디터와 중요한 정보를 효과적으로 알릴 수 있는 포맷팅 타임라인 기능. 웹에서 비디오 녹화까지.' } }, { 'type': 'paragraph', 'data': { 'text': '쉽게 제작하고, 효율적으로 온라인 강의를 체험해보세요' } }], 'version': '2.18.0' };
 
 export const defaultSlideData: SlideState = {
   id: '0',

--- a/client/src/components/VideoEdit/styles.ts
+++ b/client/src/components/VideoEdit/styles.ts
@@ -1,28 +1,9 @@
 import styled from 'styled-components';
 
-export const Scaffold = styled.div`
-  font-family: 'SpoqaHanSans';
-
-  display: flex;
-  flex-direction: row;
-`;
-export const VideoContainer = styled.div`
-  flex: 1;
-  max-width: 30rem;
-  
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-`;
 export const CameraVideo = styled.video`
   transform: scaleX(-1);
-`;
-export const PreviewVideo = styled.video`
-  transform: scaleX(-1);
-`;
-export const EditorContainer = styled.div`
-  flex: 1;
-`;
-export const RecordButton = styled.button`
-  font-size: 2rem;
+  width: 100%;
+  border-radius: 0.25rem;
+  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.375);
+  background: ${({theme}) => theme.colors.text.caption};
 `;

--- a/client/src/components/VideoEdit/utils.ts
+++ b/client/src/components/VideoEdit/utils.ts
@@ -9,7 +9,7 @@ export const uploadVideoToServer = (video: Blob) => {
   
 export const getCameraMirrorRefCallback = () => {
   return useCallback<(el: HTMLVideoElement) => void>((el) => {
-    navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then((stream) => {
+    navigator.mediaDevices.getUserMedia({ audio: true, video: { width: 1280, height: 720 } }).then((stream) => {
       if (el === null) {
         return;
       }

--- a/client/src/components/VideoEdit/utils.ts
+++ b/client/src/components/VideoEdit/utils.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+import axios from 'axios';
+
+export const uploadVideoToServer = (video: Blob) => {
+  const formData = new FormData();
+  formData.append('video', video);
+  return axios.post('http://10.10.20.230:3001/upload-video', formData);
+};
+  
+export const getCameraMirrorRefCallback = () => {
+  return useCallback<(el: HTMLVideoElement) => void>((el) => {
+    navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then((stream) => {
+      if (el === null) {
+        return;
+      }
+      el.srcObject = stream;
+    });
+  }, []);
+};
+  

--- a/client/src/components/editor-page/EditorToolBar/index.tsx
+++ b/client/src/components/editor-page/EditorToolBar/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Row, Col } from 'react-grid-system';
+import Headroom from 'react-headroom';
+
 import CTAButton from '@src/components/common/CTAButton';
 import FlatButton from '@src/components/common/FlatButton';
 
@@ -17,32 +19,34 @@ const EditorToolBar: React.FC<EditorToolBarProps> = ({
   lectureName = '길범준의 노래방 강의',
 }) => {
   return (
-    <S.ToolbarWrapper fluid>
-      <Row align="center">
-        <Col>
-          <S.TitleWrapper>
-            <S.Symbol />
-            <div>
-              <input
-                type="text"
-                value={name}
-                placeholder="새로운 강의 이름"
-                onChange={onNameChanged}
-                disabled={!onNameChanged}
-              />
-              <p>{lectureName}</p>
-            </div>
-          </S.TitleWrapper>
-        </Col>
-        <Col>
-          <S.ButtonWrapper>
-            <FlatButton>임시저장(?)</FlatButton>
-            <div style={{width: 24}}/>
-            <CTAButton>업로드</CTAButton>
-          </S.ButtonWrapper>
-        </Col>
-      </Row>
-    </S.ToolbarWrapper>
+    <Headroom>
+      <S.ToolbarWrapper fluid>
+        <Row align="center">
+          <Col>
+            <S.TitleWrapper>
+              <S.Symbol />
+              <div>
+                <input
+                  type="text"
+                  value={name}
+                  placeholder="새로운 강의 이름"
+                  onChange={onNameChanged}
+                  disabled={!onNameChanged}
+                />
+                <p>{lectureName}</p>
+              </div>
+            </S.TitleWrapper>
+          </Col>
+          <Col>
+            <S.ButtonWrapper>
+              <FlatButton>임시저장(?)</FlatButton>
+              <div style={{width: 24}}/>
+              <CTAButton>업로드</CTAButton>
+            </S.ButtonWrapper>
+          </Col>
+        </Row>
+      </S.ToolbarWrapper>
+    </Headroom>
   );
 };
 

--- a/client/src/styles/EditorWrapper.ts
+++ b/client/src/styles/EditorWrapper.ts
@@ -37,7 +37,7 @@ const paragraphStyle = css`
     font-family: 'KoPub Batang', serif;
     color: ${({theme}) => theme.colors.text.default};
     font-size: 1.375rem;
-    
+    word-break: keep-all;
     b {
       color: ${({theme}) => theme.colors.black};
     }
@@ -152,7 +152,13 @@ const inlineToolStyle = css`
 `;
 
 const blockStyle = css`
+  .ce-toolbar__content {
+    max-width: none;
+  }
   .ce-block {
+    &__content {
+      max-width: none;
+    }
     &--drop-target {
       > div {
         border: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,6 +1718,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-headroom@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/react-headroom/-/react-headroom-2.2.1.tgz#54f2cf222aa4411c9948bc6078658de23269d90f"
+  integrity sha512-BVfra15oucJnSEImUEivP+QXSevdnf2Tf5ED65vO3S1uB8GxAjbxKkLmFPvfKU9EwaFnSdstgFdnhi7SK6atiw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@*":
   version "0.63.1"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.1.tgz#81da30aeaaa034039efd23ccb1c54786b1630966"
@@ -6492,6 +6499,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -6933,7 +6945,7 @@ prop-types-exact@1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7075,6 +7087,13 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+raf@^3.3.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 random-bytes@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
@@ -7136,6 +7155,15 @@ react-grid-system@^7.0.3:
   integrity sha512-8ppMdkKFu6geeg8bjvR0Yq54aUDcf9ghP5zcWg/po0ThRCbyLvadyNImjN2ZrL/zy3daEJpVtTq638N0FtmPDw==
   dependencies:
     prop-types "^15.7.2"
+
+react-headroom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-headroom/-/react-headroom-3.0.0.tgz#6d74102ccc04b060269ddee6e5b788f476e0eca6"
+  integrity sha512-iVRDowuHHvIBuOx/IoEg2uPqQl8myGgtth55IMZ6SdJkJ/NIz9VUMIC9bsfGU5GLc6AzksFRKQmuaDftjqjzMw==
+  dependencies:
+    prop-types "^15.5.8"
+    raf "^3.3.0"
+    shallowequal "^1.1.0"
 
 react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
### 이 PR 은 무엇이 변경되었나요? ✏️

![image](https://user-images.githubusercontent.com/24666383/87860538-4b504900-c979-11ea-9df8-799a5acaafd7.png)

- 구조를 익힐겸 UI를 입혔어요. 시간이 없어 대충했습니다. 
- 사용성 관련 문제들을 좀 찾았습니다

`setCurrentSlide` 이 친구가 제일 큰 문제입니다. 아래 문제들이 발생해요.
1. 포맷팅 타임라인 Preview를 할 때 쌓아둔 초기화/재생이 불가합니다.
2. isRecording이 slide마다 있는데 다른 index로 갈 때 녹화를 끊지 않아요. 그래서 여전히 녹화중이라고 뜨죠.
3. 1번 슬라이드에 포커스 후 녹화를 시작한 상태로 2번에 포맷팅을 하면 녹화가 되지 않아요. (일단 다른 슬라이드를 눌렀을 경우 currentSlide를 수정하는 로직은 제가 추가했어요)

그래서 이렇게 바꿀 수 있으면 좋을거 같아요.
1. currentSlide가 바뀔 때 기존 녹화를 종료하거나, buffer로 로컬에 들고있기
2. 각 슬라이드마다 uuid를 부여하여 포맷팅 타임라인 녹화를 슬라이드 단위가 아닌 전체단위에서 '해당 uuid의 슬라이드가 ...으로 변경했다'를 찍기