### PR TITLE
feat(client): axios 기반 API Request 관리 기능 추가

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,9 @@
     "editorjs-drag-drop": "^0.1.0",
     "fontfaceobserver": "^2.1.0",
     "immer": "^7.0.5",
+    "jwt-decode": "^2.2.0",
     "next": "^9.4.4",
+    "nookies": "^2.3.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-grid-system": "^7.0.3",
@@ -34,6 +36,7 @@
   "devDependencies": {
     "@svgr/webpack": "^5.4.0",
     "@types/fontfaceobserver": "^0.0.6",
+    "@types/jwt-decode": "^2.2.1",
     "@types/node": "^14.0.22",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",

--- a/client/src/utils/ApiRequest/index.ts
+++ b/client/src/utils/ApiRequest/index.ts
@@ -1,0 +1,73 @@
+import axios from 'axios';
+import jwt_decode from 'jwt-decode';
+import {setCookie, parseCookies, destroyCookie} from 'nookies';
+
+import Router from 'next/router';
+import User from '@shared/src/entity/User';
+
+const ACCESS_TOKEN_STORE_KEY = 'esruoc-access-token';
+
+const axiosInstance = axios.create({
+  baseURL: 'http://localhost:8000',
+});
+
+axiosInstance.interceptors.request.use((request) => {
+  if (getUserInfo()) {
+    request.headers['Authorization'] = getSavedToken();
+  }
+
+  return request;
+});
+
+axiosInstance.interceptors.response.use((response) => {
+  if (response.status == 200 && response.request.url.endsWith('/user/login')) {
+    setAccessToken(response.data.accessToken);
+  }
+
+  return response;
+}, function (error) {
+  if (error.response.status === 401 && !error.response.request.url.endsWith('/user/login')) {
+    deleteAccessToken();
+    _gotoMain();
+
+    return error;
+  }
+});
+
+export const setAccessToken = (accessToken: string) => {
+  try {
+    jwt_decode(accessToken);
+
+    setCookie(null, ACCESS_TOKEN_STORE_KEY, accessToken, {
+      maxAge: 7 * 24 * 60 * 60,
+      path: '/',
+    });
+  } catch (e) {
+    _gotoMain();
+  }
+};
+
+export const deleteAccessToken = () => {
+  destroyCookie(null, ACCESS_TOKEN_STORE_KEY);
+};
+
+export const getSavedToken = (): string => {
+  return parseCookies()[ACCESS_TOKEN_STORE_KEY];
+};
+
+export const getUserInfo = (): User | undefined => {
+  const accessToken = getSavedToken();
+
+  if (accessToken) {
+    const decodedToken = jwt_decode(accessToken);
+    return decodedToken as User;
+  }
+
+  return undefined;
+};
+
+const _gotoMain = () => {
+  Router.push('/');
+};
+
+export default axiosInstance;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,6 +1645,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/jwt-decode@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
+  integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
+
 "@types/long@^4.0.0", "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
@@ -5310,6 +5315,11 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
 kareem@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.1.tgz#def12d9c941017fabfb00f873af95e9c99e1be87"
@@ -6111,6 +6121,14 @@ nodemon@^2.0.4:
     touch "^3.1.0"
     undefsafe "^2.0.2"
     update-notifier "^4.0.0"
+
+nookies@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/nookies/-/nookies-2.3.2.tgz#5a6111dc8f7247d3b532f35a073fe4e408c8f027"
+  integrity sha512-iV0aRpJhpmf3Ri7q0tulK5epR8sYvYuifphVwSMlm/SIt0gVII+R6lSDYNgLJLFMCK+9gvJC6H87vSCA4CtKcA==
+  dependencies:
+    cookie "^0.4.0"
+    set-cookie-parser "^2.4.3"
 
 nopt@~1.0.10:
   version "1.0.10"
@@ -7618,6 +7636,11 @@ serve-static@1.14.1:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.17.1"
+
+set-cookie-parser@^2.4.3:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.6.tgz#43bdea028b9e6f176474ee5298e758b4a44799c3"
+  integrity sha512-mNCnTUF0OYPwYzSHbdRdCfNNHqrne+HS5tS5xNb6yJbdP9wInV0q5xPLE0EyfV/Q3tImo3y/OXpD8Jn0Jtnjrg==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
### 이 PR 은 무엇이 변경되었나요? ✏️

- `axios` 를 사용해서 API Request 를 관리하는 기능을 추가했어요.
	- 로그인 API 인 `/user/login` 에서 인증을 성공할 경우, `axios` 에서 `Authorization` 헤더를 넣도록 했습니다.