### PR TITLE
fix(server): 내가 만든 강의 갖고오는 로직 변경

### DIFF
--- a/server/src/business/LectureService.ts
+++ b/server/src/business/LectureService.ts
@@ -32,13 +32,11 @@ class LectureService {
     async getMyLectures(user: User): Promise<LectureListOutput> {
       const result: LectureOutput[] = [];
 
-      if (!user.uploadedCourses) {
-        return {lectures: []};
-      }
-      for (const uploadedId of user.uploadedCourses) {
-        const lecture = await this.lectureRepository.getLecture({'_id': new Types.ObjectId(uploadedId)});
-        const output = await this.mapLectureOutput(lecture);
-        result.push(output);
+      const lectureDocuments = await this.lectureRepository.getAllLectures();
+      for (const lectureDocument of lectureDocuments) {
+        const lecture = lectureDocument as Lecture;
+        if (lecture.uploaderId == user.uid) {const output = await this.mapLectureOutput(lecture);
+          result.push(output);}
       }
       return {lectures: result};
     }


### PR DESCRIPTION
### 이 PR 은 무엇이 변경되었나요? ✏️

- 콘텐츠 전체를 갖고와서, `uploadedBy`를 비교하도록 변경
- 왜냐구? 강의 업로드할 때, `user` DB의 `uploadedCourses`를 업데이트 하지 않거덩,,
